### PR TITLE
Increase yaw from banking

### DIFF
--- a/Assets/PlaneController.cs
+++ b/Assets/PlaneController.cs
@@ -7,7 +7,9 @@ public class PlaneController : MonoBehaviour
     public float pitchSpeed = 45f;
     public float rollSpeed = 50f;
     // Bank turn hızını ayarlamak için çarpan
-    public float bankTurnSpeed = 2f;
+    // Sağa/sola dönüşlerde uçağın daha hızlı yön değiştirebilmesi için
+    // bankeden elde edilen dönüş hızını artırıyoruz.
+    public float bankTurnSpeed = 50f;
 
     private Rigidbody rb;
 


### PR DESCRIPTION
## Summary
- speed up bank yaw by default so the plane actually turns

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68401cc33e34832981cf56e4afcbb769